### PR TITLE
change from moment's deprecated .zone() to .utcOffset()

### DIFF
--- a/lib/datetimeWrapper.js
+++ b/lib/datetimeWrapper.js
@@ -163,7 +163,7 @@ var datetimeWrapper = function(moment) {
      */
     formatFromOffset: function(timestamp, offset, mask) {
       mask = mask || DEFAULT_DISPLAY_MASK;
-      return _applyMask(moment(timestamp).zone(-offset), mask);
+      return _applyMask(moment(timestamp).utcOffset(offset), mask);
     },
     /*
      * Format the given timestamp for storage
@@ -174,10 +174,7 @@ var datetimeWrapper = function(moment) {
      * @return {String} an ISO8601-formatted timestamp
      */
     formatForStorage: function(timestamp, offset) {
-      console.warn('Warning! This method used to expect an offset ~to~ UTC, but now it expects and offset ~from~ UTC. Double-check your usage.');
-      // we use -offset here because moment deals in offsets that are ~to~ UTC
-      // but we store JavaScript Date-style offsets that are ~from~ UTC
-      return moment(timestamp).zone(-offset).format();
+      return moment(timestamp).utcOffset(offset).format();
     },
     /*
      * Format the given timestamp for display in the given named timezone
@@ -231,7 +228,7 @@ var datetimeWrapper = function(moment) {
       }
       // we use -offset here because moment deals in offsets that are ~to~ UTC
       // but we store JavaScript Date-style offsets that are ~from~ UTC
-      return dt.zone(-offset) - dt.clone().zone(-offset).startOf('day');
+      return dt.utcOffset(offset) - dt.clone().utcOffset(offset).startOf('day');
     },
     /*
      * Get the offset from the current date
@@ -239,7 +236,7 @@ var datetimeWrapper = function(moment) {
      * @return {String} number of minutes offset ~from~ UTC
      */
     getOffset: function() {
-      return -moment().zone();
+      return moment().utcOffset();
     },
     /*
      * Get the offset from the given date
@@ -247,15 +244,14 @@ var datetimeWrapper = function(moment) {
      * @return {String} number of minutes offset ~from~ UTC
      */
     getOffsetFromTime: function(timestamp) {
-      console.warn('Warning! This method used to return the offset ~to~ UTC, but now it returns the offset ~from~ UTC. Double-check your usage.');
       function containsZone() {
         var zonePattern = /^([+-][0-2]\d:[0-5]\d)$/;
         return zonePattern.test(timestamp.slice(-6));
       }
       if (containsZone()) {
-        return -moment.parseZone(timestamp).zone();
+        return moment.parseZone(timestamp).utcOffset();
       }
-      return -moment(timestamp).zone();
+      return moment(timestamp).utcOffset();
     },
     /*
      * Get the offset from the given UTC date plus named timezone
@@ -264,7 +260,7 @@ var datetimeWrapper = function(moment) {
      */
     getOffsetFromZone: function(timestamp, timezone) {
       this.checkTimezoneName(timezone);
-      return -moment.utc(timestamp).tz(timezone).zone();
+      return moment.utc(timestamp).tz(timezone).utcOffset();
     },
     /*
      * Get all timezone objects

--- a/test/test_datetimeWrapper.js
+++ b/test/test_datetimeWrapper.js
@@ -319,8 +319,8 @@ describe('sundial', function() {
       it('has the offset from UTC',function(){
 
         var utcString = datetimeWrapper.formatForStorage(basicTimestamp,offsetMins);
-        var offsetFromTimestamp = testMoment.parseZone(utcString).zone();
-        expect(-offsetFromTimestamp).to.equal(offsetMins);
+        var offsetFromTimestamp = testMoment.parseZone(utcString).utcOffset();
+        expect(offsetFromTimestamp).to.equal(offsetMins);
 
       });
       it('does not contain the `Z` designator for the zero UTC offset',function(){


### PR DESCRIPTION
What it says on the tin. Also remove our method warnings because we've updated our internal use of sundial everywhere now, I believe.

See https://github.com/moment/moment/issues/1779 and https://github.com/moment/moment/pull/2074 for the moment change. They have deprecated `.zone()` in favor of `.utcOffset()` which accepts and returns a value *opposite in sign* to what `.zone()` used to accept and return (which is good because we formerly had to reverse the sign because they were doing it pretty much opposite everyone else).

@jh-bate review?