### PR TITLE
fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ results
 
 npm-debug.log
 node_modules
+tmp
 
 .idea
 *.iml

--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ Run unit tests with:
 ```bash
 $ npm test
 ```
+
+Run the tests in-browser locally with:
+
+```bash
+$ npm run browser-tests
+```

--- a/package.json
+++ b/package.json
@@ -37,17 +37,21 @@
   "main": "sundial.js",
   "repository": "https://github.com/tidepool-org/sundial.git",
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "browser-tests": "node_modules/.bin/testem"
   },
   "dependencies": {
     "moment-timezone": "0.3.0"
   },
   "devDependencies": {
+    "chai": "3.3.0",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
     "grunt-contrib-jshint": "0.11.0",
     "grunt-mocha-test": "0.12.7",
+    "json-loader": "0.5.3",
     "mocha": "2.1.0",
-    "salinity": "0.0.7"
+    "testem": "0.9.7",
+    "webpack": "1.12.2"
   }
 }

--- a/test/test_datetimeWrapper.js
+++ b/test/test_datetimeWrapper.js
@@ -15,8 +15,8 @@
 
 'use strict';
 
-var salinity = require('salinity');
-var expect = salinity.expect;
+var chai = require('chai');
+var expect = chai.expect;
 var testMoment = require('moment-timezone');
 
 describe('sundial', function() {

--- a/test/test_datetimeWrapper.js
+++ b/test/test_datetimeWrapper.js
@@ -278,18 +278,19 @@ describe('sundial', function() {
 
     describe('findTimeFromDeviceTimeAndOffsets', function() {
       it('should just add `.000Z` when all offsets are 0', function() {
-        var ts = '2013-03-06T10:13:00';
-        var res = datetimeWrapper.findTimeFromDeviceTimeAndOffsets(new Date(ts), 0, 0);
-        expect(res.toISOString()).to.equal(ts + '.000Z');
+        var ts = '2013-03-06T10:13:00.000Z';
+        var jsDate = Date.UTC(2013,2,6,10,13,0);
+        var res = datetimeWrapper.findTimeFromDeviceTimeAndOffsets(jsDate, 0, 0);
+        expect(res.toISOString()).to.equal(ts);
       });
 
       it('should yield a UTC timestamp such that time + timezoneOffset + conversionOffset = deviceTime', function() {
-        var ts = '2014-01-01T00:00:00';
-        var res1 = datetimeWrapper.findTimeFromDeviceTimeAndOffsets(new Date(ts), 0, -120000);
+        var jsDate = Date.UTC(2014,0,1,0,0,0);
+        var res1 = datetimeWrapper.findTimeFromDeviceTimeAndOffsets(new Date(jsDate), 0, -120000);
         expect(res1.toISOString()).to.equal('2014-01-01T00:02:00.000Z');
-        var res2 = datetimeWrapper.findTimeFromDeviceTimeAndOffsets(new Date(ts), -600, 0);
+        var res2 = datetimeWrapper.findTimeFromDeviceTimeAndOffsets(new Date(jsDate), -600, 0);
         expect(res2.toISOString()).to.equal('2014-01-01T10:00:00.000Z');
-        var res3 = datetimeWrapper.findTimeFromDeviceTimeAndOffsets(new Date(ts), -480, -120000);
+        var res3 = datetimeWrapper.findTimeFromDeviceTimeAndOffsets(new Date(jsDate), -480, -120000);
         expect(res3.toISOString()).to.equal('2014-01-01T08:02:00.000Z');
       });
     });

--- a/testem.json
+++ b/testem.json
@@ -1,0 +1,12 @@
+{
+  "after_tests": "rm -rf tmp/_test.js",
+  "before_tests": "./node_modules/.bin/webpack --config tests.config.js",
+  "framework": "mocha+chai",
+  "launch_in_dev": [ "chrome" ],
+  "serve_files": [
+    "tmp/_test.js" 
+  ],
+  "src_files": [
+    "lib/**/*.js"
+  ]
+}

--- a/tests.config.js
+++ b/tests.config.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var path = require('path');
+
+module.exports = {
+  entry: './test/test_datetimeWrapper.js',
+  output: {
+    path: path.join(__dirname, 'tmp'),
+    filename: '_test.js'
+  },
+  module: {
+    loaders: [
+      {test: /\.json$/, loader: 'json-loader'}
+    ]
+  }
+};


### PR DESCRIPTION
The first commit here adds the ability to run the tests in Chrome using [testem](https://github.com/airportyh/testem) (IMO, this is faster to set up than Karma, and I just wanted to see if the tests were broken in-browser).

If you check out the first commit and run the tests with `npm run browser-tests` you'll see two failures. The second commit fixes those failures by removing reliance on the prior behavior of JavaScript Date in Chrome (that passing a Date string like `2015-01-01T00:00:00` with no TZ info would be interpreted as a UTC timestamp equivalent to `2015-01-01T00:00:00.000Z`).

I suggest for now that we commit to running tests regularly/daily locally in-browser and discuss the prioritization of getting tests running with CI in real browsers - and not only that, but in real browsers *in non-UTC time* (whatever remote machines are running the browsers can't be UTC boxes, if we want to expose these types of issues).