### PR TITLE
[WEB-3359] release for dependency update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sundial",
-  "version": "1.7.5",
+  "version": "1.7.6-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sundial",
-      "version": "1.7.5",
+      "version": "1.7.6-rc.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "moment-timezone": "0.5.43"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sundial",
-  "version": "1.7.5",
+  "version": "1.7.6-rc.1",
   "description": "Tidepool's datetime wrapper",
   "keywords": [
     "datetime",


### PR DESCRIPTION
to resolve [WEB-3359], this largely is just to get a release version number that includes this PR: https://github.com/tidepool-org/sundial/pull/39

downstream PRs:
blip - https://github.com/tidepool-org/blip/pull/1906
viz - https://github.com/tidepool-org/viz/pull/611
tideline - https://github.com/tidepool-org/tideline/pull/526
~~uploader - https://github.com/tidepool-org/uploader/pull/1739~~
ble-glucose - https://github.com/tidepool-org/ble-glucose/pull/28
export - https://github.com/tidepool-org/export/pull/83
jellyfish - https://github.com/tidepool-org/jellyfish/pull/211
message-api - https://github.com/tidepool-org/message-api/pull/105